### PR TITLE
Implement recording of spans as transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-eyre = "0.6"
-sentry-core = { version = "0.21" }
-sentry-backtrace = "0.21"
-serde = "1.0"
-serde_json = "1.0"
-strip-ansi-escapes = "0.1"
+sentry-core = "0.22"
+sentry-backtrace = "0.22"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 
+[dependencies.strip-ansi-escapes]
+version = "0.1"
+optional = true
+
 [dev-dependencies]
-sentry = "0.21"
+sentry = "0.22"

--- a/src/converters.rs
+++ b/src/converters.rs
@@ -1,11 +1,21 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    fmt::{Debug, Display},
+};
 
+use protocol::TraceContext;
 use sentry_backtrace::current_stacktrace;
-use sentry_core::protocol::{Event, Exception};
-use sentry_core::Breadcrumb;
-use tracing::field::Field;
+use sentry_core::{
+    event_from_error,
+    protocol::Value,
+    protocol::{self, Event, Exception},
+    Breadcrumb,
+};
+use tracing::{field::Field, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
-use crate::TracingIntegrationOptions;
+use crate::layer::Trace;
 
 fn convert_tracing_level(level: &tracing::Level) -> sentry_core::Level {
     match level {
@@ -16,90 +26,61 @@ fn convert_tracing_level(level: &tracing::Level) -> sentry_core::Level {
     }
 }
 
-#[derive(Default)]
-struct FieldVisitorConfig {
+/// Configures how sentry event and span data is recorded
+// from tracing event and spans attributes
+#[derive(Clone, Copy)]
+pub struct FieldVisitorConfig<'a> {
     /// If set to true, ansi escape sequences will be stripped from
     /// string values, and formatted error/debug values.
+    #[cfg(features = "strip-ansi-escapes")]
     pub strip_ansi_escapes: bool,
-    ///
+
     /// If `Some`, values for tracing events with the field name
-    /// matching what is specified here will be included in the event
-    /// type string: "[target](event_type) tracing event".
-    pub event_type_field: Option<String>,
-}
-
-impl From<&TracingIntegrationOptions> for FieldVisitorConfig {
-    fn from(integration: &TracingIntegrationOptions) -> Self {
-        Self {
-            strip_ansi_escapes: integration.strip_ansi_escapes,
-            event_type_field: integration.event_type_field.clone(),
-        }
-    }
+    /// matching what is specified here will be included as the event
+    /// message string.
+    pub event_type_field: Option<&'a str>,
 }
 
 #[derive(Default)]
-struct FieldVisitorResult {
-    pub display_values: Vec<String>,
-    pub json_values: BTreeMap<String, serde_json::Value>,
-    pub log_target: Option<String>,
-    pub event_type: Option<String>,
+pub(crate) struct FieldVisitorResult {
+    pub(crate) event_type: Option<String>,
+    pub(crate) json_values: BTreeMap<String, Value>,
+    pub(crate) expections: Vec<Exception>,
 }
 
-impl FieldVisitorResult {
-    fn message(&self) -> String {
-        self.display_values.join("\n")
-    }
+pub(crate) struct FieldVisitor<'a> {
+    config: FieldVisitorConfig<'a>,
+    result: &'a mut FieldVisitorResult,
 }
 
-#[derive(Default)]
-struct FieldVisitor {
-    config: FieldVisitorConfig,
-    result: FieldVisitorResult,
-}
-
-impl FieldVisitor {
-    fn visit_event(event: &tracing::Event<'_>, config: FieldVisitorConfig) -> FieldVisitorResult {
-        let mut visitor = Self {
-            config,
-            ..Self::default()
-        };
-
-        event.record(&mut visitor);
-        visitor.result
+impl<'a> FieldVisitor<'a> {
+    pub(crate) fn new(config: FieldVisitorConfig<'a>, result: &'a mut FieldVisitorResult) -> Self {
+        Self { config, result }
     }
 
-    fn record_json_value<S: serde::Serialize>(&mut self, field: &Field, value: &S) {
-        match serde_json::to_value(value) {
-            Ok(json_value) => {
-                self.result
-                    .json_values
-                    .insert(field.name().to_owned(), json_value);
-            }
-            Err(error) => {
-                let error = eyre::eyre!(
-                    "Error while serializing the \"{}\" field to json: {}",
-                    field.name(),
-                    error
-                );
-                tracing::error!(error = ?error)
-            }
-        }
-    }
-
-    fn record_value_message(&mut self, field: &Field, value: &str) {
-        if let Some(field_name) = &self.config.event_type_field {
-            if field.name() == field_name {
-                self.result.event_type = Some(value.to_owned());
-            }
-        }
+    fn record_json_value(&mut self, field: &Field, json_value: Value) {
         self.result
-            .display_values
-            .push(format!("{}={}", field, value));
+            .json_values
+            .insert(field.name().to_owned(), json_value);
+    }
+
+    /// Try to record this field as the `event_type`, returns true if the field was
+    /// inserted and false if the value was discarded
+    fn try_record_event_type(&mut self, field: &Field, value: impl Display) -> bool {
+        if let Some(event_type_field) = self.config.event_type_field {
+            if field.name() == event_type_field {
+                self.result.event_type = Some(value.to_string());
+                return true;
+            }
+        }
+
+        false
     }
 }
 
 /// Strips ansi color escape codes from string, or returns the
 /// original string if there was problem performing the strip.
+#[cfg(features = "strip-ansi-escapes")]
 pub fn strip_ansi_codes_from_string(string: &str) -> String {
     if let Ok(stripped_bytes) = strip_ansi_escapes::strip(string.as_bytes()) {
         if let Ok(stripped_string) = std::str::from_utf8(&stripped_bytes) {
@@ -110,80 +91,83 @@ pub fn strip_ansi_codes_from_string(string: &str) -> String {
     string.to_owned()
 }
 
-impl tracing::field::Visit for FieldVisitor {
+impl<'a> tracing::field::Visit for FieldVisitor<'a> {
     /// Visit a signed 64-bit integer value.
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.record_json_value(field, &value);
-        self.record_value_message(field, &format!("{:?}", value));
+        if !self.try_record_event_type(field, value) {
+            self.record_json_value(field, Value::Number(value.into()));
+        }
     }
 
     /// Visit an unsigned 64-bit integer value.
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.record_json_value(field, &value);
-        self.record_value_message(field, &&format!("{:?}", value));
+        if !self.try_record_event_type(field, value) {
+            self.record_json_value(field, Value::Number(value.into()));
+        }
     }
 
     /// Visit a boolean value.
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.record_json_value(field, &value);
-        self.record_value_message(field, &&format!("{:?}", value));
+        if !self.try_record_event_type(field, value) {
+            self.record_json_value(field, Value::Bool(value));
+        }
     }
 
     /// Visit an `&str` value.
     fn record_str(&mut self, field: &Field, value: &str) {
+        #[cfg(features = "strip-ansi-escapes")]
         let value = if self.config.strip_ansi_escapes {
             strip_ansi_codes_from_string(&value)
         } else {
             value.to_owned()
         };
 
-        if field.name() == "log.target" {
-            self.result.log_target = Some(value.clone());
+        if !self.try_record_event_type(field, &value) {
+            self.record_json_value(field, Value::String(value.into()));
         }
-
-        self.record_json_value(field, &value);
-        self.record_value_message(field, &value);
     }
 
     /// Visit a type that implements `std::error::Error`.
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        let formatted_value = format!("{:?}", value);
-        let message_string = if self.config.strip_ansi_escapes {
-            strip_ansi_codes_from_string(&formatted_value)
-        } else {
-            formatted_value
-        };
-
-        self.record_json_value(field, &message_string);
-        self.record_value_message(field, &message_string);
+    fn record_error(&mut self, _field: &Field, value: &(dyn Error + 'static)) {
+        // As exception_from_error is not public, this calls event_from_error
+        // instead and extract the Exception struct from the resulting Event
+        let event = event_from_error(value);
+        for exception in event.exception {
+            self.result.expections.push(exception);
+        }
     }
 
     /// Visit a type that implements `std::fmt::Debug`.
-    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        let formatted_value = format!("{:?}", value);
-        let message_string = if self.config.strip_ansi_escapes {
-            strip_ansi_codes_from_string(&formatted_value)
-        } else {
-            formatted_value
-        };
+    #[cfg_attr(not(features = "strip-ansi-escapes"), allow(unused_mut))]
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        let mut formatted_value = format!("{:?}", value);
 
-        self.record_json_value(field, &message_string);
-        self.record_value_message(field, &message_string);
+        #[cfg(features = "strip-ansi-escapes")]
+        if self.config.strip_ansi_escapes {
+            formatted_value = strip_ansi_codes_from_string(&formatted_value)
+        }
+
+        if !self.try_record_event_type(field, &formatted_value) {
+            self.record_json_value(field, Value::String(formatted_value));
+        }
     }
 }
 
 /// Creates a breadcrumb from a given tracing event.
 pub fn breadcrumb_from_event(
     event: &tracing::Event<'_>,
-    integration: &TracingIntegrationOptions,
+    visitor_config: FieldVisitorConfig,
 ) -> Breadcrumb {
-    let visitor_result = FieldVisitor::visit_event(event, integration.into());
+    let mut visitor_result = FieldVisitorResult::default();
+    let mut visitor = FieldVisitor::new(visitor_config, &mut visitor_result);
+
+    event.record(&mut visitor);
 
     Breadcrumb {
         ty: "log".into(),
         level: convert_tracing_level(event.metadata().level()),
         category: Some(event.metadata().target().into()),
-        message: Some(visitor_result.message()),
+        message: visitor_result.event_type,
         data: visitor_result.json_values,
         ..Default::default()
     }
@@ -191,45 +175,64 @@ pub fn breadcrumb_from_event(
 
 /// Creates an event from a given log record.
 ///
-/// If `with_stacktrace` is set to `true` then a stacktrace is attached
+/// If `attach_stacktraces` is set to `true` then a stacktrace is attached
 /// from the current frame.
-pub fn convert_tracing_event(
+pub fn convert_tracing_event<S>(
     event: &tracing::Event<'_>,
-    options: &TracingIntegrationOptions,
-) -> Event<'static> {
-    let visitor_result = FieldVisitor::visit_event(event, options.into());
+    ctx: Context<S>,
+    attach_stacktraces: bool,
+    visitor_config: FieldVisitorConfig,
+) -> Event<'static>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let mut visitor_result = FieldVisitorResult::default();
+    let mut visitor = FieldVisitor::new(visitor_config, &mut visitor_result);
+    event.record(&mut visitor);
 
-    // Special support for log.target reported by tracing-log
-    let (exception_target, exception_source) = match &visitor_result.log_target {
-        Some(log_target) => (log_target.as_str(), "log event"),
-        None => (event.metadata().target(), "tracing event"),
-    };
-
-    let mut exception_type = String::new();
-    exception_type.push_str(&format!("[{}]", exception_target));
-
-    if let Some(event_type) = &visitor_result.event_type {
-        exception_type.push_str(&format!("({})", event_type));
-    }
-
-    exception_type.push(' ');
-    exception_type.push_str(exception_source);
-
-    Event {
-        logger: Some("sentry-tracing".into()),
-        level: convert_tracing_level(event.metadata().level()),
-        exception: vec![Exception {
-            ty: exception_type,
-            value: Some(visitor_result.message()),
-            stacktrace: if options.attach_stacktraces {
+    let exception = if !visitor_result.expections.is_empty() {
+        visitor_result.expections
+    } else {
+        vec![Exception {
+            ty: event.metadata().name().into(),
+            value: visitor_result.event_type.clone(),
+            stacktrace: if attach_stacktraces {
                 current_stacktrace()
             } else {
                 None
             },
-            module: event.metadata().module_path().map(|p| p.to_owned()),
+            module: event.metadata().module_path().map(String::from),
             ..Default::default()
         }]
-        .into(),
+    };
+
+    let mut result = Event {
+        logger: Some("sentry-tracing".into()),
+        level: convert_tracing_level(event.metadata().level()),
+        message: visitor_result.event_type,
+        exception: exception.into(),
+        extra: visitor_result.json_values,
         ..Default::default()
+    };
+
+    let parent = event
+        .parent()
+        .and_then(|id| ctx.span(id))
+        .or_else(|| ctx.lookup_current());
+
+    if let Some(parent) = parent {
+        let extensions = parent.extensions();
+        if let Some(trace) = extensions.get::<Trace>() {
+            let context = protocol::Context::from(TraceContext {
+                span_id: trace.span_id,
+                trace_id: trace.trace_id,
+                ..TraceContext::default()
+            });
+
+            result.contexts.insert(context.type_name().into(), context);
+            result.transaction = parent.parents().last().map(|root| root.name().into());
+        }
     }
+
+    result
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1,38 +1,49 @@
 use sentry_core::{ClientOptions, Integration};
-use tracing_subscriber::EnvFilter;
+use tracing::Subscriber;
+use tracing_subscriber::{registry::LookupSpan, EnvFilter};
+
+use crate::{
+    converters::{
+        default_convert_breadcrumb, default_convert_event, default_convert_transaction,
+        default_new_span, default_on_close,
+    },
+    layer::{ConvertBreadcrumb, ConvertEvent, ConvertTransaction, NewSpan, OnClose},
+};
 
 /// Integration that performs
-#[derive(Debug)]
-pub struct TracingIntegrationOptions {
+pub struct TracingIntegrationOptions<S> {
     /// Events matching this filter will be sent to sentry as events
     pub event_filter: EnvFilter,
     /// Events matching this filter will be sent to sentry as breadcrumb
     pub breadcrumb_filter: EnvFilter,
     /// Spans matching this filter will be sent to sentry as transactions
     pub span_filter: EnvFilter,
-    /// If set to `true` current stacktrace will be resolved and attached
-    /// to each event. (expensive, defaults to `true`).
-    pub attach_stacktraces: bool,
-    /// If set to true, ansi escape sequences will be stripped from
-    /// string values, and formatted error/debug values.
-    #[cfg(features = "strip-ansi-escapes")]
-    pub strip_ansi_escapes: bool,
-    /// If `Some`, values for tracing events with the field name
-    /// matching what is specified here will be included in the event
-    /// type string: "[target](event_type) tracing event".
-    pub event_type_field: Option<String>,
+    /// Defines how a tracing event should be converted into a sentry event
+    pub convert_event: ConvertEvent<S>,
+    /// Defines how a tracing event should be converted into a sentry breadcrumb
+    pub convert_breadcrumb: ConvertBreadcrumb<S>,
+    /// Defines how a tracing span should be converted into a sentry span
+    pub new_span: NewSpan<S>,
+    /// Allows inserting additional data into a span as it finishes (such as timings)
+    pub on_close: OnClose,
+    /// Defines how a set of spans should be converted into a sentry transaction
+    pub convert_transaction: ConvertTransaction<S>,
 }
 
-impl Default for TracingIntegrationOptions {
+impl<S> Default for TracingIntegrationOptions<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
     fn default() -> Self {
         Self {
             event_filter: EnvFilter::new("error"),
             breadcrumb_filter: EnvFilter::new("info"),
             span_filter: EnvFilter::default(),
-            attach_stacktraces: true,
-            #[cfg(features = "strip-ansi-escapes")]
-            strip_ansi_escapes: true,
-            event_type_field: None,
+            convert_event: Box::new(default_convert_event),
+            convert_breadcrumb: Box::new(default_convert_breadcrumb),
+            new_span: Box::new(default_new_span),
+            on_close: Box::new(default_on_close),
+            convert_transaction: Box::new(default_convert_transaction),
         }
     }
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1,23 +1,21 @@
 use sentry_core::{ClientOptions, Integration};
-use tracing::Level;
 use tracing_subscriber::EnvFilter;
 
 /// Integration that performs
 #[derive(Debug)]
 pub struct TracingIntegrationOptions {
-    /// The sentry specific tracing span/event level filter (defaults to `info`).
-    pub filter: EnvFilter,
-    /// If set to `true`, breadcrumbs will be emitted. (defaults to `true`).
-    pub emit_breadcrumbs: bool,
-    /// If set to `true` error events will be sent for errors in the log. (defaults to `true`).
-    pub emit_error_events: bool,
-    /// If set to `true` warning events will be sent for warnings in the log. (defaults to `false`).
-    pub emit_warning_events: bool,
+    /// Events matching this filter will be sent to sentry as events
+    pub event_filter: EnvFilter,
+    /// Events matching this filter will be sent to sentry as breadcrumb
+    pub breadcrumb_filter: EnvFilter,
+    /// Spans matching this filter will be sent to sentry as transactions
+    pub span_filter: EnvFilter,
     /// If set to `true` current stacktrace will be resolved and attached
     /// to each event. (expensive, defaults to `true`).
     pub attach_stacktraces: bool,
     /// If set to true, ansi escape sequences will be stripped from
     /// string values, and formatted error/debug values.
+    #[cfg(features = "strip-ansi-escapes")]
     pub strip_ansi_escapes: bool,
     /// If `Some`, values for tracing events with the field name
     /// matching what is specified here will be included in the event
@@ -28,12 +26,12 @@ pub struct TracingIntegrationOptions {
 impl Default for TracingIntegrationOptions {
     fn default() -> Self {
         Self {
-            filter: EnvFilter::new("info"),
-            emit_breadcrumbs: true,
-            emit_error_events: true,
-            emit_warning_events: false,
+            event_filter: EnvFilter::new("error"),
+            breadcrumb_filter: EnvFilter::new("info"),
+            span_filter: EnvFilter::default(),
             attach_stacktraces: true,
-            strip_ansi_escapes: false,
+            #[cfg(features = "strip-ansi-escapes")]
+            strip_ansi_escapes: true,
             event_type_field: None,
         }
     }
@@ -41,31 +39,8 @@ impl Default for TracingIntegrationOptions {
 
 /// A Sentry [Integration] for capturing events/spans from the
 /// `tracing` framework.
-pub struct TracingIntegration {
-    pub(crate) options: TracingIntegrationOptions,
-}
-
-impl TracingIntegration {
-    /// Create a new [TracingIntegration] with the specified `options`.
-    pub fn new(options: TracingIntegrationOptions) -> Self {
-        Self { options }
-    }
-
-    /// Checks if an issue should be created.
-    pub(crate) fn create_issue_for_event(&self, event: &tracing::Event<'_>) -> bool {
-        match event.metadata().level() {
-            &Level::WARN => self.options.emit_warning_events,
-            &Level::ERROR => self.options.emit_error_events,
-            _ => false,
-        }
-    }
-}
-
-impl Default for TracingIntegration {
-    fn default() -> Self {
-        Self::new(TracingIntegrationOptions::default())
-    }
-}
+#[derive(Default)]
+pub struct TracingIntegration;
 
 impl Integration for TracingIntegration {
     fn name(&self) -> &'static str {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,41 +1,459 @@
-use crate::{breadcrumb_from_event, converters::convert_tracing_event, TracingIntegration};
+use std::{
+    cmp::max,
+    mem::swap,
+    time::{Instant, SystemTime},
+};
 
-use sentry_core::Hub;
-use tracing::{span, Event, Subscriber};
-use tracing_subscriber::{layer::Context, Layer};
+use crate::{
+    converters::{
+        breadcrumb_from_event, convert_tracing_event, FieldVisitor, FieldVisitorConfig,
+        FieldVisitorResult,
+    },
+    TracingIntegrationOptions,
+};
+
+use sentry_core::{
+    add_breadcrumb, capture_event,
+    protocol::{self, Transaction, Value},
+    types::Uuid,
+    Envelope, Hub,
+};
+use tracing::{metadata::LevelFilter, span, subscriber::Interest, Event, Subscriber};
+use tracing_subscriber::{
+    layer::{Context, Layered},
+    registry::{LookupSpan, SpanRef},
+    EnvFilter, Layer,
+};
 
 /// Provides a dispatching logger.
-#[derive(Default)]
-pub struct SentryLayer;
+pub struct SentryLayer<S> {
+    span_layer: Layered<EnvFilter, SpanLayer, S>,
+    event_layer: Layered<EnvFilter, EventLayer, S>,
+    breadcrumb_layer: Layered<EnvFilter, BreadcrumbLayer, S>,
+}
 
-impl<S: Subscriber> Layer<S> for SentryLayer {
+impl<S> SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    /// Create a new layer instance with the specified options
+    pub fn new(options: TracingIntegrationOptions) -> Self {
+        let span_layer = SpanLayer {
+            #[cfg(features = "strip-ansi-escapes")]
+            strip_ansi_escapes: options.strip_ansi_escapes,
+            event_type_field: options.event_type_field.clone(),
+        };
+        let event_layer = EventLayer {
+            #[cfg(features = "strip-ansi-escapes")]
+            strip_ansi_escapes: options.strip_ansi_escapes,
+            attach_stacktraces: options.attach_stacktraces,
+            event_type_field: options.event_type_field.clone(),
+        };
+        let breadcrumb_layer = BreadcrumbLayer {
+            #[cfg(features = "strip-ansi-escapes")]
+            strip_ansi_escapes: options.strip_ansi_escapes,
+            event_type_field: options.event_type_field,
+        };
+
+        SentryLayer {
+            span_layer: span_layer.and_then(options.span_filter),
+            event_layer: event_layer.and_then(options.event_filter),
+            breadcrumb_layer: breadcrumb_layer.and_then(options.breadcrumb_filter),
+        }
+    }
+}
+
+impl<S> Default for SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn default() -> Self {
+        SentryLayer::new(TracingIntegrationOptions::default())
+    }
+}
+
+fn is_layer_enabled<L, S>(layer: &L, id: &tracing::Id, ctx: Context<'_, S>) -> bool
+where
+    L: Layer<S>,
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    if let Some(metadata) = ctx.metadata(id) {
+        layer.enabled(metadata, ctx)
+    } else {
+        false
+    }
+}
+
+// The SentryLayer dispatches all events and spans to all the underlying layers
+// (SpanLayer, EventLayer and BreadcrumbLayer) with "lowest common denominator" filtering
+impl<S> Layer<S> for SentryLayer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        let span = self.span_layer.register_callsite(metadata);
+        let event = self.event_layer.register_callsite(metadata);
+        let breadcrumb = self.breadcrumb_layer.register_callsite(metadata);
+
+        if span.is_always() || event.is_always() || breadcrumb.is_always() {
+            Interest::always()
+        } else if span.is_never() && event.is_never() && breadcrumb.is_never() {
+            Interest::never()
+        } else {
+            Interest::sometimes()
+        }
+    }
+
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        let span = self.span_layer.enabled(metadata, ctx.clone());
+        let event = self.event_layer.enabled(metadata, ctx.clone());
+        let breadcrumb = self.breadcrumb_layer.enabled(metadata, ctx);
+        span || event || breadcrumb
+    }
+
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, id, ctx.clone()) {
+            self.span_layer.new_span(attrs, id, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, id, ctx.clone()) {
+            self.event_layer.new_span(attrs, id, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, id, ctx.clone()) {
+            self.breadcrumb_layer.new_span(attrs, id, ctx);
+        }
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        let span = self.span_layer.max_level_hint()?;
+        let event = self.event_layer.max_level_hint()?;
+        let breadcrumb = self.breadcrumb_layer.max_level_hint()?;
+        Some(max(max(span, event), breadcrumb))
+    }
+
+    fn on_record(&self, span: &tracing::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, span, ctx.clone()) {
+            self.span_layer.on_record(span, values, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, span, ctx.clone()) {
+            self.event_layer.on_record(span, values, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, span, ctx.clone()) {
+            self.breadcrumb_layer.on_record(span, values, ctx);
+        }
+    }
+
+    fn on_follows_from(&self, span: &tracing::Id, follows: &tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, span, ctx.clone()) {
+            self.span_layer.on_follows_from(span, follows, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, span, ctx.clone()) {
+            self.event_layer.on_follows_from(span, follows, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, span, ctx.clone()) {
+            self.breadcrumb_layer.on_follows_from(span, follows, ctx);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if self.span_layer.enabled(event.metadata(), ctx.clone()) {
+            self.span_layer.on_event(event, ctx.clone());
+        }
+        if self.event_layer.enabled(event.metadata(), ctx.clone()) {
+            self.event_layer.on_event(event, ctx.clone());
+        }
+        if self.breadcrumb_layer.enabled(event.metadata(), ctx.clone()) {
+            self.breadcrumb_layer.on_event(event, ctx);
+        }
+    }
+
+    fn on_enter(&self, id: &tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, id, ctx.clone()) {
+            self.span_layer.on_enter(id, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, id, ctx.clone()) {
+            self.event_layer.on_enter(id, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, id, ctx.clone()) {
+            self.breadcrumb_layer.on_enter(id, ctx);
+        }
+    }
+
+    fn on_exit(&self, id: &tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, id, ctx.clone()) {
+            self.span_layer.on_exit(id, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, id, ctx.clone()) {
+            self.event_layer.on_exit(id, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, id, ctx.clone()) {
+            self.breadcrumb_layer.on_exit(id, ctx);
+        }
+    }
+
+    fn on_close(&self, id: tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, &id, ctx.clone()) {
+            self.span_layer.on_close(id.clone(), ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, &id, ctx.clone()) {
+            self.event_layer.on_close(id.clone(), ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, &id, ctx.clone()) {
+            self.breadcrumb_layer.on_close(id, ctx);
+        }
+    }
+
+    fn on_id_change(&self, old: &tracing::Id, new: &tracing::Id, ctx: Context<'_, S>) {
+        if is_layer_enabled(&self.span_layer, old, ctx.clone()) {
+            self.span_layer.on_id_change(old, new, ctx.clone());
+        }
+        if is_layer_enabled(&self.event_layer, old, ctx.clone()) {
+            self.event_layer.on_id_change(old, new, ctx.clone());
+        }
+        if is_layer_enabled(&self.breadcrumb_layer, old, ctx.clone()) {
+            self.breadcrumb_layer.on_id_change(old, new, ctx);
+        }
+    }
+}
+
+/// The event layer sends all the spans it receives to Sentry as transactions
+struct SpanLayer {
+    #[cfg(features = "strip-ansi-escapes")]
+    strip_ansi_escapes: bool,
+    event_type_field: Option<String>,
+}
+
+impl<S> Layer<S> for SpanLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        // TODO: implement sampling rate
+        if extensions.get_mut::<Trace>().is_none() {
+            let mut trace = Trace::new(&span);
+            let mut visitor = FieldVisitor::new(
+                FieldVisitorConfig {
+                    #[cfg(features = "strip-ansi-escapes")]
+                    strip_ansi_escapes: self.strip_ansi_escapes,
+                    event_type_field: self.event_type_field.as_deref(),
+                },
+                &mut trace.visitor,
+            );
+
+            attrs.record(&mut visitor);
+            extensions.insert(trace);
+        }
+    }
+
     /// Notifies this layer that a span with the given ID was entered.
-    fn on_enter(&self, _id: &span::Id, _ctx: Context<'_, S>) {}
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
 
-    /// Notifies this layer that an event has occurred.
-    fn on_event(&self, event: &Event<'_>, context: Context<'_, S>) {
-        let recorded =
-            sentry_core::with_integration(|integration: &TracingIntegration, hub: &Hub| {
-                if integration.create_issue_for_event(event) {
-                    hub.capture_event(convert_tracing_event(event, &integration.options));
-                }
+        if let Some(timings) = extensions.get_mut::<Trace>() {
+            let now = Instant::now();
+            timings.idle += (now - timings.last).as_nanos() as u64;
+            timings.last = now;
+        }
+    }
 
-                if integration.options.emit_breadcrumbs
-                    && integration
-                        .options
-                        .filter
-                        .enabled(event.metadata(), context)
-                {
-                    sentry_core::add_breadcrumb(|| {
-                        breadcrumb_from_event(event, &integration.options)
-                    });
-                }
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
 
-                true
+        if let Some(timings) = extensions.get_mut::<Trace>() {
+            let now = Instant::now();
+            timings.busy += (now - timings.last).as_nanos() as u64;
+            timings.last = now;
+            timings.last_sys = SystemTime::now();
+        }
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        let trace = match extensions.get_mut::<Trace>() {
+            Some(trace) => trace,
+            None => return,
+        };
+
+        let name: String = span.name().into();
+        let span_id = trace.span_id;
+        let trace_id = trace.trace_id;
+
+        let busy = trace.busy;
+        let mut idle = trace.idle;
+        let first = trace.first;
+        let last = trace.last;
+        let last_sys = trace.last_sys;
+
+        idle += (Instant::now() - last).as_nanos() as u64;
+
+        let mut visitor = FieldVisitorResult::default();
+        let mut spans = Vec::new();
+
+        swap(&mut visitor, &mut trace.visitor);
+        swap(&mut spans, &mut trace.spans);
+
+        visitor
+            .json_values
+            .insert(String::from("busy"), Value::Number(busy.into()));
+        visitor
+            .json_values
+            .insert(String::from("idle"), Value::Number(idle.into()));
+
+        let mut span_data = protocol::Span {
+            span_id,
+            trace_id,
+            op: Some(name.clone()),
+            description: visitor.event_type,
+            start_timestamp: first.into(),
+            timestamp: Some(last_sys.into()),
+            data: visitor.json_values,
+            // TODO: propagate error status from child span / event ?
+            // TODO: extract status from error object ?
+            status: if visitor.expections.is_empty() {
+                Some(String::from("ok"))
+            } else {
+                Some(String::from("internal_error"))
+            },
+            ..protocol::Span::default()
+        };
+
+        // Traverse the parents of this span to attach to the nearest one
+        // that has tracing data (spans ignored by the span_filter do not)
+        for parent in span.parents() {
+            let mut extensions = parent.extensions_mut();
+            if let Some(parent) = extensions.get_mut::<Trace>() {
+                parent.spans.extend(spans);
+
+                span_data.parent_span_id = Some(parent.span_id.to_simple_ref().to_string());
+                parent.spans.push(span_data);
+                return;
+            }
+        }
+
+        // If no parent was found, consider this span a
+        // transaction root and submit it to Sentry
+        Hub::with_active(move |hub| {
+            let mut envelope = Envelope::new();
+            envelope.add_item(Transaction {
+                event_id: trace_id,
+                name: Some(name),
+                start_timestamp: first.into(),
+                timestamp: Some(last_sys.into()),
+                spans,
+                ..Transaction::default()
             });
 
-        if !recorded {
-            eprintln!("Tracing event was not recorded by sentry because it has no `TracingIntegration` applied.")
+            let client = hub.client().unwrap();
+            client.send_envelope(envelope);
+        });
+    }
+}
+
+/// The event layer sends all the events it receives to Sentry as events
+struct EventLayer {
+    #[cfg(features = "strip-ansi-escapes")]
+    strip_ansi_escapes: bool,
+    attach_stacktraces: bool,
+    event_type_field: Option<String>,
+}
+
+impl<S> Layer<S> for EventLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    /// Notifies this layer that an event has occurred.
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        capture_event(convert_tracing_event(
+            event,
+            ctx,
+            self.attach_stacktraces,
+            FieldVisitorConfig {
+                #[cfg(features = "strip-ansi-escapes")]
+                strip_ansi_escapes: self.strip_ansi_escapes,
+                event_type_field: self.event_type_field.as_deref(),
+            },
+        ));
+    }
+}
+
+/// The breadcrumb layer sends all the events it receives to Sentry as breadcrumbs
+struct BreadcrumbLayer {
+    #[cfg(features = "strip-ansi-escapes")]
+    strip_ansi_escapes: bool,
+    event_type_field: Option<String>,
+}
+
+impl<S> Layer<S> for BreadcrumbLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    /// Notifies this layer that an event has occurred.
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        add_breadcrumb(|| {
+            breadcrumb_from_event(
+                event,
+                FieldVisitorConfig {
+                    #[cfg(features = "strip-ansi-escapes")]
+                    strip_ansi_escapes: self.strip_ansi_escapes,
+                    event_type_field: self.event_type_field.as_deref(),
+                },
+            )
+        });
+    }
+}
+
+pub(crate) struct Trace {
+    pub(crate) span_id: Uuid,
+    pub(crate) trace_id: Uuid,
+
+    visitor: FieldVisitorResult,
+    spans: Vec<protocol::Span>,
+
+    // From the tracing-subscriber implementation of span timings,
+    // with additional SystemTime informations to reconstruct the UTC
+    // times needed by Sentry
+    idle: u64,
+    busy: u64,
+    last: Instant,
+    first: SystemTime,
+    last_sys: SystemTime,
+}
+
+impl Trace {
+    fn new<R>(span: &SpanRef<R>) -> Self
+    where
+        R: for<'a> LookupSpan<'a>,
+    {
+        let trace_id = span
+            .parent()
+            .and_then(|parent| {
+                let extensions = parent.extensions();
+                let trace = extensions.get::<Trace>()?;
+                Some(trace.trace_id.clone())
+            })
+            .unwrap_or_else(Uuid::new_v4);
+
+        Trace {
+            span_id: Uuid::new_v4(),
+            trace_id,
+
+            visitor: FieldVisitorResult::default(),
+            spans: Vec::new(),
+
+            idle: 0,
+            busy: 0,
+            last: Instant::now(),
+            first: SystemTime::now(),
+            last_sys: SystemTime::now(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ mod converters;
 mod integration;
 mod layer;
 
-pub use converters::{breadcrumb_from_event, convert_tracing_event, FieldVisitorConfig};
+pub use converters::{
+    breadcrumb_from_event, convert_tracing_event, default_convert_breadcrumb,
+    default_convert_event, default_convert_transaction, default_new_span, default_on_close,
+    FieldVisitorConfig,
+};
 pub use integration::{TracingIntegration, TracingIntegrationOptions};
 pub use layer::SentryLayer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@ mod converters;
 mod integration;
 mod layer;
 
-pub use converters::{breadcrumb_from_event, convert_tracing_event};
+pub use converters::{breadcrumb_from_event, convert_tracing_event, FieldVisitorConfig};
 pub use integration::{TracingIntegration, TracingIntegrationOptions};
 pub use layer::SentryLayer;


### PR DESCRIPTION
- Refactor the configuration to use EnvFilters for events, breadcrumbs and spans
- Move the configuration out of the integration object and into the tracing layers (limit hub lookup in the layers)
- Trim dependencies / move strip-ansi-escape to a cargo feature
- Make event formatting less opinionated (ideally this would be configurable with callbacks in the configuration instead)
- Move event / breadcrumb / span conversion into boxed functions replaceable through the options struct

From: https://github.com/levels3d/sentry-tracing